### PR TITLE
shorter urls config

### DIFF
--- a/wiki/LocalSettings.php
+++ b/wiki/LocalSettings.php
@@ -31,6 +31,9 @@ $wgMetaNamespace = "Meta";
 ## (like /w/index.php/Page_title to /wiki/Page_title) please see:
 ## https://www.mediawiki.org/wiki/Manual:Short_URL
 $wgScriptPath = "";
+$wgArticlePath = "/$1";
+$wgUsePathInfo = true;
+$wgScriptExtension = ".php";
 
 ## The protocol and server name to use in fully-qualified URLs
 $wgServer = "https://wiki.internal.jamboree.se.webservices.scouterna.net";


### PR DESCRIPTION
Updated LocalSettings according to [Manual:Short_URL](https://www.mediawiki.org/wiki/Manual:Short_URL)
and [Manual:Short_URL/Page_title](https://www.mediawiki.org/wiki/Manual:Short_URL/Page_title_-_nginx,_Root_Access,_PHP_as_a_CGI_module)

So we can use shorter urls.
Before: https://wiki.internal.jamboree.se.webservices.scouterna.net/index.php/Projektplan
After: https://wiki.internal.jamboree.se.webservices.scouterna.net/Projektplan