### PR TITLE
Allow the use of DISPLAYTITLE in wiki

### DIFF
--- a/wiki/LocalSettings.php
+++ b/wiki/LocalSettings.php
@@ -25,6 +25,9 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 $wgSitename = "Jamboree21";
 $wgMetaNamespace = "Meta";
 
+# Allow DISPLAYTITLE to contain anything, default is to restrict it to only format-changes.
+$wgRestrictDisplayTitle = false;
+
 ## The URL base path to the directory containing the wiki;
 ## defaults for all runtime URL paths are based off of this.
 ## For more information on customizing the URLs


### PR DESCRIPTION
Allow the use of DISPLAYTITLE, to completly change the title, not only format-changes.

https://www.mediawiki.org/wiki/Manual:$wgRestrictDisplayTitle