### PR TITLE
Add helm chart

### DIFF
--- a/.charts/jamboree21/Chart.yaml
+++ b/.charts/jamboree21/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: jamboree21
+description: Support systems for Jamboree21
+version: 1.0.0
+appVersion: 0.0.1

--- a/.charts/jamboree21/secrets.yaml
+++ b/.charts/jamboree21/secrets.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.localsecrets -}}
+apiVersion: v1
+data:
+  mediawiki_secret_key: YjY4NDc1NmNhNTc0ZDM0ZDllODM1YmUxYzk0NzA5MWRhNWQ1NDI2MzVjOTg3MzEyMDQ5ODcyODhlYmVlOTg3Yg==
+  mediawiki_upgrade_key: c3hxc09aZWt6bzJib25QRlJqVFF0QXpBU2JORnlFekU=
+kind: Secret
+metadata:
+  name: mediawiki-secrets
+  namespace: jamboree21
+type: Opaque
+---
+apiVersion: v1
+data:
+  postgres_db: bWVkaWF3aWtp
+  postgres_password: QWhyMGZpaWNlb3F1aTJDaGdlZXBpMUFlb2hqYWgyQ2g=
+  postgres_user: d2lraQ==
+kind: Secret
+metadata:
+  annotations: {}
+  name: db-credentials
+  namespace: jamboree21
+type: Opaque
+---
+apiVersion: v1
+data:
+  saml_admin_password: aGFja3NwZXR0
+  saml_app_id: c3BuOjFkMDY3YTFlLTdjODktNDViZi05NzBjLTg3NjM2MGFhY2VkNQ==
+  saml_idp: aHR0cHM6Ly9zdHMud2luZG93cy5uZXQvMzE3YTQ3YmEtZmQzMi00MWI4LThlYmUtMzEwYTFhZGM5ODYzLw==
+  saml_secret_salt: azBJZmJYM3kwR3JrQXRFVkZ0Q0ZPRXZmNjI1T0NjdjBYU0dtMVM3RUZLQ0hackFaOElwWFRTMEY3V3NCWG45Yw==
+kind: Secret
+metadata:
+  name: saml-credentials
+  namespace: jamboree21
+type: Opaque
+{{- end }}

--- a/.charts/jamboree21/templates/mariadb.yaml
+++ b/.charts/jamboree21/templates/mariadb.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations: {}
+  name: wikidata
+  namespace: jamboree21
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 16Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  name: mariadb
+  namespace: jamboree21
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: postgres_db
+              name: db-credentials
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: postgres_user
+              name: db-credentials
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres_password
+              name: db-credentials
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres_password
+              name: db-credentials
+        image: mariadb:10
+        imagePullPolicy: IfNotPresent
+        name: mariadb
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: wikidata
+      volumes:
+      - name: wikidata
+        persistentVolumeClaim:
+          claimName: wikidata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: mariadb
+  name: wikidb
+  namespace: jamboree21
+spec:
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app: mariadb
+  type: ClusterIP

--- a/.charts/jamboree21/templates/mediawiki-env.yaml
+++ b/.charts/jamboree21/templates/mediawiki-env.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data:
+  MEDIAWIKI_ADMIN_PASS: admin
+  MEDIAWIKI_ADMIN_USER: admin
+  MEDIAWIKI_DB_HOST: wikidb
+  MEDIAWIKI_DB_PORT: "3306"
+  MEDIAWIKI_DB_TYPE: mysql
+  MEDIAWIKI_SITE_LANG: sv
+  MEDIAWIKI_SITE_NAME: Jamboree21 wiki
+  MEDIAWIKI_SITE_SERVER: {{ .Values.wiki.baseurl | default "https://wiki.internal.jamboree.se.webservices.scouterna.net" }}
+  MEDIAWIKI_UPDATE: "false"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: mediawiki
+  name: mediawiki-env
+  namespace: jamboree21

--- a/.charts/jamboree21/templates/mediawiki.yaml
+++ b/.charts/jamboree21/templates/mediawiki.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.wiki.storage.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations: {}
+  name: wikiimages
+  namespace: jamboree21
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  {{ if .Values.wiki.storage.classname }}
+  storageClassName: {{ .Values.wiki.storage.classname | default "default" }}
+  {{ end }}
+{{ end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  name: mediawiki
+  namespace: jamboree21
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mediawiki
+  template:
+    metadata:
+      labels:
+        app: mediawiki
+    spec:
+      containers:
+      - env:
+        - name: MEDIAWIKI_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: postgres_db
+              name: db-credentials
+        - name: MEDIAWIKI_DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: postgres_user
+              name: db-credentials
+        - name: MEDIAWIKI_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres_password
+              name: db-credentials
+        - name: MEDIAWIKI_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: mediawiki_secret_key
+              name: mediawiki-secrets
+        - name: MEDIAWIKI_UPGRADE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: mediawiki_upgrade_key
+              name: mediawiki-secrets
+        - name: SAML_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: saml_admin_password
+              name: saml-credentials
+        - name: SAML_SECRET_SALT
+          valueFrom:
+            secretKeyRef:
+              key: saml_secret_salt
+              name: saml-credentials 
+        - name: SAML_APP_ID
+          valueFrom:
+            secretKeyRef:
+              key: saml_app_id
+              name: saml-credentials
+        - name: SAML_IDP
+          valueFrom:
+            secretKeyRef:
+              key: saml_idp
+              name: saml-credentials
+        envFrom:
+        - configMapRef:
+            name: mediawiki-env
+        image: {{ .Values.wiki.image | default "wiki:latest" }}
+        {{ if (eq "local" .Values.environment) }}
+        imagePullPolicy: Never
+        {{ else }}
+        imagePullPolicy: Always
+        {{ end }}
+        name: wiki
+        volumeMounts:
+        - mountPath: /var/www/html/images
+          name: images
+      volumes:
+      - name: images
+        persistentVolumeClaim:
+          claimName: wikiimages
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  name: mediawiki
+  namespace: jamboree21
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: mediawiki

--- a/.charts/jamboree21/templates/secrets.yaml
+++ b/.charts/jamboree21/templates/secrets.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  mediawiki_secret_key: YjY4NDc1NmNhNTc0ZDM0ZDllODM1YmUxYzk0NzA5MWRhNWQ1NDI2MzVjOTg3MzEyMDQ5ODcyODhlYmVlOTg3Yg==
+  mediawiki_upgrade_key: c3hxc09aZWt6bzJib25QRlJqVFF0QXpBU2JORnlFekU=
+kind: Secret
+metadata:
+  name: mediawiki-secrets
+  namespace: jamboree21
+type: Opaque
+---
+apiVersion: v1
+data:
+  postgres_db: bWVkaWF3aWtp
+  postgres_password: QWhyMGZpaWNlb3F1aTJDaGdlZXBpMUFlb2hqYWgyQ2g=
+  postgres_user: d2lraQ==
+kind: Secret
+metadata:
+  annotations: {}
+  name: db-credentials
+  namespace: jamboree21
+type: Opaque
+---
+apiVersion: v1
+data:
+  saml_admin_password: aGFja3NwZXR0
+  saml_app_id: c3BuOjFkMDY3YTFlLTdjODktNDViZi05NzBjLTg3NjM2MGFhY2VkNQ==
+  saml_idp: aHR0cHM6Ly9zdHMud2luZG93cy5uZXQvMzE3YTQ3YmEtZmQzMi00MWI4LThlYmUtMzEwYTFhZGM5ODYzLw==
+  saml_secret_salt: azBJZmJYM3kwR3JrQXRFVkZ0Q0ZPRXZmNjI1T0NjdjBYU0dtMVM3RUZLQ0hackFaOElwWFRTMEY3V3NCWG45Yw==
+kind: Secret
+metadata:
+  name: saml-credentials
+  namespace: jamboree21
+type: Opaque

--- a/.charts/jamboree21/values.yaml
+++ b/.charts/jamboree21/values.yaml
@@ -1,0 +1,7 @@
+environment: local
+wiki:
+  localsecrets: false
+  baseurl: https://wiki.internal.jamboree.se.webservices.scouterna.net
+  image: 
+  storage:
+    enabled: true


### PR DESCRIPTION
Helm (https://helm.sh) is a templating solution for Kubernetes that
allows us to write one configuration with variables representing our
different environments (local, staging, production). This makes the
config file format *even more* unreadable, but if we're smart the only
things we'll need to edit are the values in `values.yaml`.