### PR TITLE
Switch to Scouterna version of facelist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "facelist/facelist"]
 	path = facelist/facelist
-	url = https://github.com/zentabit/facelist.git
+	url = https://github.com/Scouterna/facelist.git


### PR DESCRIPTION
Move from a private version of facelist, to one hosted on our own organisation.