### PR TITLE
facelist: mount config in /etc

### DIFF
--- a/facelist/.k8s/deployment.yaml
+++ b/facelist/.k8s/deployment.yaml
@@ -13,9 +13,11 @@ spec:
       containers:
         - image: %IMAGE%
           imagePullPolicy: Always
+          command: ["/facelist"]
+          args: ["--config=/etc/facelist/facelist.yaml"]
           name: facelist
           volumeMounts:
-            - mountPath: "/"
+            - mountPath: "/etc/facelist/"
               name: facelist-config
               readOnly: true
       volumes:


### PR DESCRIPTION
we can't put a file directly in / with a volume mount, so let's put it a bit further away