### PR TITLE
wiki: Enable Cite extension for nicer references

### DIFF
--- a/wiki/LocalSettings.php
+++ b/wiki/LocalSettings.php
@@ -159,6 +159,7 @@ wfLoadSkin( 'Vector' );
 # wfLoadExtensions('ExtensionName');
 # to LocalSettings.php. Check specific extension documentation for more details.
 # The following extensions were automatically enabled:
+wfLoadExtension( 'Cite' );
 wfLoadExtension( 'MultimediaViewer' );
 wfLoadExtension( 'PdfHandler' );
 wfLoadExtension( 'WikiEditor' );


### PR DESCRIPTION
It's shipped with MW but disabled by default: https://www.mediawiki.org/wiki/Extension:Cite#Configuration