### PR TITLE
wiki: Fix SMW complaining about update key

### DIFF
--- a/wiki/Dockerfile
+++ b/wiki/Dockerfile
@@ -35,3 +35,4 @@ RUN COMPOSER=composer.local.json php composer.phar install
 RUN php composer.phar update --no-dev
 
 COPY LocalSettings.php LocalSettings.php
+COPY smw.json /var/www/html/extensions/SemanticMediaWiki/.smw.json

--- a/wiki/smw.json
+++ b/wiki/smw.json
@@ -1,0 +1,9 @@
+{
+    "mediawiki": {
+        "upgrade_key": "ecb6a57621ea1cbfb76860ddc03f44df504775c2",
+        "maintenance_mode": false,
+        "latest_version": "3.2.3",
+        "incomplete_tasks": [],
+        "last_optimization_run": "2021-09-14 03:39"
+    }
+}


### PR DESCRIPTION
When Semantic Mediawiki is installed, it generates an upgrade key. If
this key changes, it's a sign that database schema migrations are
needed. To check if it has changed, a file is saved to disk with the
current key.

Since our disks are ephemeral on the pods, every time the wiki is
redeployed (or restarted for any other reason) the upgrade key is
missing and migrations need to be re-run.

This adds the upgrade key in the expected place, so we should be able to
restart until migrations are needed for real.