### PR TITLE
build: handle substring names in check-update.sh

### DIFF
--- a/.azure-pipelines/scripts/check-update-status.sh
+++ b/.azure-pipelines/scripts/check-update-status.sh
@@ -1,22 +1,23 @@
 #!/bin/bash -e
 
-target=$(echo "${MONOREPO_BUILD_TARGET:-$1}" | tr '[:upper:]' '[:lower:]')
-subpath="${SUBPATH:-$2}"
+target="$1"
+subpath="$2"
 
 if [[ "$target" == "" ]] || [[ "$subpath" == "" ]]; then
 	echo "Usage: ./$0 [<build target> [<subpath>]]"
-	echo "Arguments can also be provided through the environment variables"
-	echo "\$MONOREPO_BUILD_TARGET and \$SUBPATH"
 	exit 1
 fi
 
-tag="$(git tag | grep "$target" | tail -n 1 | tr -d '\n')"
+tag="$(git tag | grep build-"$target"- | tail -n 1 | tr -d '\n')"
 
 updated='false'
 
 if [[ "$tag" == "" ]] || [[ "$(git log "$tag"..HEAD --format=%h -- "$subpath" | tr -d '\n')" != "" ]]; then
 	updated='true'
+	echo "Updates to $target since the last build:"
+	git log "$tag"..HEAD --format=oneline -- "$subpath"
 fi
+
 
 echo "The $target project is $([[ "$updated" == 'true' ]] && echo 'updated' || echo 'not updated') since the last build."
 


### PR DESCRIPTION
Service names should be allowed to be part of other service names.
